### PR TITLE
chore: update ossrh token to central portal token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,11 +14,11 @@ runs:
       uses: Keeper-Security/ksm-action@v1
       with:
         keeper-secret-config: ${{ inputs.keeper-secret-config }}
-        secrets: |
+        secrets: |          
           UMJm296qDNVf1lj83G3Uwg/field/login > env:JFROG_USER
           UMJm296qDNVf1lj83G3Uwg/field/password > env:JFROG_TOKEN
-          VwaCAh2QiR4E4sVaSz_rEQ/field/login > env:CENTRAL_USERNAME
-          VwaCAh2QiR4E4sVaSz_rEQ/field/password > env:CENTRAL_PSW
+          9YxF6pdnV9G-rC8m9As56g/field/login > env:CENTRAL_USERNAME
+          9YxF6pdnV9G-rC8m9As56g/field/password > env:CENTRAL_PSW
           1W-qBXHmaENw-ZmeMzDS4A/field/login > env:GPG_KEYNAME
           1W-qBXHmaENw-ZmeMzDS4A/custom_field/gpg-private-key > env:GPG_PRIVATE_KEY
           1W-qBXHmaENw-ZmeMzDS4A/field/password > env:MAVEN_GPG_PASSPHRASE

--- a/action.yml
+++ b/action.yml
@@ -71,18 +71,7 @@ runs:
               "snapshots": {
                 "enabled": "true"
               }
-            },
-            {
-                "id": "central-snapshots",
-                "name": "central-snapshots",
-                "url" : "https://central.sonatype.com/repository/maven-snapshots/",
-                "releases": {
-                "enabled": "false"
-              },
-              "snapshots": {
-                "enabled": "true"
-              }
-            },
+            },           
             {
               "id": "ext-release-local",
               "name": "ext-release-local",
@@ -117,17 +106,6 @@ runs:
               },
               "snapshots": {
                 "enabled": "true"
-              }
-            },
-            {
-                "id": "central-snapshots",
-                "name": "central-snapshots",
-                "url" : "https://central.sonatype.com/repository/maven-snapshots/",
-                "releases": {
-                  "enabled": "false"
-                },
-                "snapshots": {
-                  "enabled": "true"
               }
             }
           ]

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,8 @@ runs:
         secrets: |
           UMJm296qDNVf1lj83G3Uwg/field/login > env:JFROG_USER
           UMJm296qDNVf1lj83G3Uwg/field/password > env:JFROG_TOKEN
-          9aU6tget4-Q-1alHvAIp5g/field/login > env:OSSRH_USERNAME
-          9aU6tget4-Q-1alHvAIp5g/field/password > env:OSSRH_PSW
+          VwaCAh2QiR4E4sVaSz_rEQ/field/login > env:CENTRAL_USERNAME
+          VwaCAh2QiR4E4sVaSz_rEQ/field/password > env:CENTRAL_PSW
           1W-qBXHmaENw-ZmeMzDS4A/field/login > env:GPG_KEYNAME
           1W-qBXHmaENw-ZmeMzDS4A/custom_field/gpg-private-key > env:GPG_PRIVATE_KEY
           1W-qBXHmaENw-ZmeMzDS4A/field/password > env:MAVEN_GPG_PASSPHRASE
@@ -73,9 +73,9 @@ runs:
               }
             },
             {
-                "id": "ossrh-snapshots",
-                "name": "ossrh-snapshots",
-                "url" : "https://oss.sonatype.org/content/repositories/snapshots",
+                "id": "central-snapshots",
+                "name": "central-snapshots",
+                "url" : "https://central.sonatype.com/repository/maven-snapshots/",
                 "releases": {
                 "enabled": "false"
               },
@@ -120,14 +120,14 @@ runs:
               }
             },
             {
-                "id": "ossrh-snapshots",
-                "name": "ossrh-snapshots",
-                "url" : "https://oss.sonatype.org/content/repositories/snapshots",
+                "id": "central-snapshots",
+                "name": "central-snapshots",
+                "url" : "https://central.sonatype.com/repository/maven-snapshots/",
                 "releases": {
-                "enabled": "false"
+                  "enabled": "false"
                 },
                 "snapshots": {
-                "enabled": "true"
+                  "enabled": "true"
               }
             }
           ]
@@ -149,9 +149,9 @@ runs:
               "password": "${{ env.JFROG_TOKEN }}"
             },
             {
-              "id": "ossrh",
-              "username": "${{ env.OSSRH_USERNAME }}",
-              "password": "${{ env.OSSRH_PSW }}"
+              "id": "central",
+              "username": "${{ env.CENTRAL_USERNAME }}",
+              "password": "${{ env.CENTRAL_PSW }}"
             },
             {
               "id": "ext-release-local",

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ runs:
       uses: Keeper-Security/ksm-action@v1
       with:
         keeper-secret-config: ${{ inputs.keeper-secret-config }}
-        secrets: |          
+        secrets: |
           UMJm296qDNVf1lj83G3Uwg/field/login > env:JFROG_USER
           UMJm296qDNVf1lj83G3Uwg/field/password > env:JFROG_TOKEN
           9aU6tget4-Q-1alHvAIp5g/field/login > env:CENTRAL_USERNAME
@@ -30,12 +30,12 @@ runs:
         gpg_private_key: ${{ env.GPG_PRIVATE_KEY }}
         passphrase: ${{ env.MAVEN_GPG_PASSPHRASE }}
         fingerprint: ${{ env.GPG_KEYNAME }}
- 
+
     - name: Setup Maven configuration
       uses: whelk-io/maven-settings-xml-action@v22
       with:
         profiles: >
-          [ 
+          [
             {
               "id" : "gpg",
               "properties": {
@@ -44,10 +44,10 @@ runs:
             }
           ]
         active_profiles: >
-         [
-           "gpg",
-           "github"
-         ]
+          [
+            "gpg",
+            "github"
+          ]
         repositories: >
           [
             {
@@ -71,7 +71,7 @@ runs:
               "snapshots": {
                 "enabled": "true"
               }
-            },           
+            },
             {
               "id": "ext-release-local",
               "name": "ext-release-local",
@@ -81,6 +81,17 @@ runs:
               },
               "snapshots": {
                 "enabled": "false"
+              }
+            },
+            {
+              "id": "central-portal-snapshots",
+              "name": "central-portal-snapshots",
+              "url": "https://central.sonatype.com/repository/maven-snapshots/",
+              "releases": {
+                "enabled": "false"
+              },
+              "snapshots": {
+                "enabled": "true"
               }
             }
           ]
@@ -101,6 +112,17 @@ runs:
               "id": "snapshots",
               "name": "snapshots",
               "url": "https://bonitasoft.jfrog.io/artifactory/snapshots",
+              "releases": {
+                "enabled": "false"
+              },
+              "snapshots": {
+                "enabled": "true"
+              }
+            },
+            {
+              "id": "central-portal-snapshots",
+              "name": "central-portal-snapshots",
+              "url": "https://central.sonatype.com/repository/maven-snapshots/",
               "releases": {
                 "enabled": "false"
               },

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,8 @@ runs:
         secrets: |          
           UMJm296qDNVf1lj83G3Uwg/field/login > env:JFROG_USER
           UMJm296qDNVf1lj83G3Uwg/field/password > env:JFROG_TOKEN
-          9YxF6pdnV9G-rC8m9As56g/field/login > env:CENTRAL_USERNAME
-          9YxF6pdnV9G-rC8m9As56g/field/password > env:CENTRAL_PSW
+          9aU6tget4-Q-1alHvAIp5g/field/login > env:CENTRAL_USERNAME
+          9aU6tget4-Q-1alHvAIp5g/field/password > env:CENTRAL_PSW
           1W-qBXHmaENw-ZmeMzDS4A/field/login > env:GPG_KEYNAME
           1W-qBXHmaENw-ZmeMzDS4A/custom_field/gpg-private-key > env:GPG_PRIVATE_KEY
           1W-qBXHmaENw-ZmeMzDS4A/field/password > env:MAVEN_GPG_PASSPHRASE


### PR DESCRIPTION
Update the maven settings action configuration to manage the access to maven central portal since ossrh are deprecated and deleted

Cover [BPA-96](https://bonitasoft.atlassian.net/browse/BPA-96)

[BPA-96]: https://bonitasoft.atlassian.net/browse/BPA-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ