### PR TITLE
refactor(settings): generate settings.xml without third-party action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.m2/repository/
-          key: ${{ runner.os }}-maven
+          key: ${{ runner.os }}-maven-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
   
       - name: Execute local action
         uses: ./
@@ -31,3 +33,18 @@ jobs:
 
       - name: Test maven settings
         run: mvn dependency:get -Dartifact=com.bonitasoft:bonita-test-toolkit:1.0.2:pom
+
+      # Also asserts that the secrets exported by the action are readable from a step of
+      # the calling workflow, which is what makes the ${env.*} references resolvable.
+      - name: Test gpg.keyname property is resolved
+        run: |
+          if [[ -z "${GPG_KEYNAME:-}" ]]; then
+            echo "::error::GPG_KEYNAME did not reach the calling workflow environment"
+            exit 1
+          fi
+          keyname=$(mvn -q org.apache.maven.plugins:maven-help-plugin:3.5.2:evaluate \
+            -Dexpression=gpg.keyname -DforceStdout)
+          if [[ "$keyname" != "$GPG_KEYNAME" ]]; then
+            echo "::error::gpg.keyname resolved to '$keyname' instead of the imported GPG key"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Maven Settings Action
 
-Composite Github Action to setup Maven settings with Bonitasoft Artifactory repository.
-Intend for internal usage only.
+Composite GitHub Action to set up Maven settings with Bonitasoft Artifactory repository.
+Intended for internal usage only.
 
 ## Input
 
@@ -21,3 +21,62 @@ jobs:
         with:
           keeper-secret-config: ${{ secrets.KSM_CONFIG }}
 ```
+
+## Avoid overriding settings.xml
+
+Place this action after any other step that writes `~/.m2/settings.xml` — such as
+`actions/setup-java` or an `actions/cache` on `~/.m2` — and before the Maven command,
+otherwise the generated `settings.xml` gets overridden.
+
+```yaml
+jobs:
+  maven-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - name: Cache Maven
+        uses: actions/cache@v6
+        with:
+          # ~/.m2/repository, never ~/.m2, which would also cache settings.xml
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven
+
+      - name: Setup Maven Settings
+        uses: bonitasoft/maven-settings-action@TAGNAME
+        with:
+          keeper-secret-config: ${{ secrets.KSM_CONFIG }}
+
+      - name: Build
+        run: mvn -B deploy
+```
+
+## Generated settings.xml
+
+[`settings.xml`](settings.xml) is copied verbatim to `~/.m2/settings.xml`, overwriting any
+existing file.
+
+It contains **no credential**: servers reference `${env.*}` expressions that Maven resolves
+when it reads the file. The action exports those variables to the job environment via
+Keeper, so Maven must run **in the same job** as this action — the variables are not
+available to other jobs, nor inside a container started manually with `docker run`.
+
+`GITHUB_ACTOR` and `GITHUB_TOKEN` back the `github` server. `GITHUB_ACTOR` is already set
+in every job by GitHub Actions, but `GITHUB_TOKEN` is not exported automatically — set it
+yourself if your build resolves from or publishes to GitHub Packages.
+
+A `401` from Artifactory usually means the variables did not reach the Maven process,
+leaving the `${env.*}` expressions unresolved: check that Maven runs in the same job as
+this action. It can also be a stale credential (e.g. a rotated JFROG token in Keeper).
+Or, on a `401` from `maven.pkg.github.com`, a missing `GITHUB_TOKEN` in the job.
+
+The `gpg.keyname` property is set to the fingerprint of the imported GPG key; see the
+linked [`settings.xml`](settings.xml) for the servers, repositories and plugin
+repositories it defines.

--- a/action.yml
+++ b/action.yml
@@ -24,145 +24,24 @@ runs:
           1W-qBXHmaENw-ZmeMzDS4A/field/password > env:MAVEN_GPG_PASSPHRASE
 
     - name: Import GPG key
-      id: import-gpg
       uses: crazy-max/ghaction-import-gpg@v7
       with:
         gpg_private_key: ${{ env.GPG_PRIVATE_KEY }}
         passphrase: ${{ env.MAVEN_GPG_PASSPHRASE }}
         fingerprint: ${{ env.GPG_KEYNAME }}
 
+    # settings.xml holds no credentials: it references ${env.*}, which Maven resolves at
+    # build time from the job environment — populated by the Keeper step above, except
+    # GITHUB_ACTOR (GitHub default variable) and GITHUB_TOKEN (set by the calling workflow).
     - name: Setup Maven configuration
-      uses: whelk-io/maven-settings-xml-action@v22
-      with:
-        profiles: >
-          [
-            {
-              "id" : "gpg",
-              "properties": {
-                "gpg.keyname": "${{ env.GPG_KEYNAME }}"
-              }
-            }
-          ]
-        active_profiles: >
-          [
-            "gpg",
-            "github"
-          ]
-        repositories: >
-          [
-            {
-              "id": "releases",
-              "name": "releases",
-              "url": "https://bonitasoft.jfrog.io/artifactory/releases",
-              "releases": {
-                "enabled": "true"
-              },
-              "snapshots": {
-                "enabled": "false"
-              }
-            },
-            {
-              "id": "snapshots",
-              "name": "snapshots",
-              "url": "https://bonitasoft.jfrog.io/artifactory/snapshots",
-              "releases": {
-                "enabled": "false"
-              },
-              "snapshots": {
-                "enabled": "true"
-              }
-            },
-            {
-              "id": "ext-release-local",
-              "name": "ext-release-local",
-              "url": "https://bonitasoft.jfrog.io/artifactory/ext-release-local",
-              "releases": {
-                "enabled": "true"
-              },
-              "snapshots": {
-                "enabled": "false"
-              }
-            },
-            {
-              "id": "central-portal-snapshots",
-              "name": "central-portal-snapshots",
-              "url": "https://central.sonatype.com/repository/maven-snapshots/",
-              "releases": {
-                "enabled": "false"
-              },
-              "snapshots": {
-                "enabled": "true"
-              }
-            }
-          ]
-        plugin_repositories: >
-          [
-            {
-              "id": "releases",
-              "name": "releases",
-              "url": "https://bonitasoft.jfrog.io/artifactory/releases",
-              "releases": {
-                "enabled": "true"
-              },
-              "snapshots": {
-                "enabled": "false"
-              }
-            },
-            {
-              "id": "snapshots",
-              "name": "snapshots",
-              "url": "https://bonitasoft.jfrog.io/artifactory/snapshots",
-              "releases": {
-                "enabled": "false"
-              },
-              "snapshots": {
-                "enabled": "true"
-              }
-            },
-            {
-              "id": "central-portal-snapshots",
-              "name": "central-portal-snapshots",
-              "url": "https://central.sonatype.com/repository/maven-snapshots/",
-              "releases": {
-                "enabled": "false"
-              },
-              "snapshots": {
-                "enabled": "true"
-              }
-            }
-          ]
-        # Github server uses env variables and not github interpolation
-        # Keep this syntax ${} and not ${{}}
-        servers: >
-          [
-            {
-              "id": "releases",
-              "username": "${{ env.JFROG_USER }}",
-              "password": "${{ env.JFROG_TOKEN }}"
-            },
-            {
-              "id": "snapshots",
-              "username": "${{ env.JFROG_USER }}",
-              "password": "${{ env.JFROG_TOKEN }}"
-            },
-            {
-              "id": "staging",
-              "username": "${{ env.JFROG_USER }}",
-              "password": "${{ env.JFROG_TOKEN }}"
-            },
-            {
-              "id": "central",
-              "username": "${{ env.CENTRAL_USERNAME }}",
-              "password": "${{ env.CENTRAL_PSW }}"
-            },
-            {
-              "id": "ext-release-local",
-              "username": "${{ env.JFROG_USER }}",
-              "password": "${{ env.JFROG_TOKEN }}"
-            },
-            {
-              "id": "github",
-              "username": "${env.GITHUB_ACTOR}",
-              "password": "${env.GITHUB_TOKEN}"
-            }
-          ]
+      shell: bash
+      run: |
+        # the required variables are derived from the file that references them
+        for var in $(grep -oP '\$\{env\.\K[A-Z_]+(?=\})' "$GITHUB_ACTION_PATH/settings.xml" | sort -u | grep -v '^GITHUB_'); do
+          if [[ -z "${!var:-}" ]]; then
+            echo "::error::$var is not set in the job environment, settings.xml would not resolve"
+            exit 1
+          fi
+        done
+        mkdir -p "$HOME/.m2"
+        cp "$GITHUB_ACTION_PATH/settings.xml" "$HOME/.m2/settings.xml"

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,145 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 https://maven.apache.org/xsd/settings-1.2.0.xsd">
+
+  <!--
+    No credential is stored in this file. Maven interpolates ${env.*} when it reads
+    settings.xml, so the values are resolved at build time from the job environment
+    populated by Keeper-Security/ksm-action (see action.yml).
+    GITHUB_ACTOR is a default GitHub Actions variable; GITHUB_TOKEN must be set by the
+    calling workflow.
+  -->
+
+  <servers>
+    <server>
+      <id>releases</id>
+      <username>${env.JFROG_USER}</username>
+      <password>${env.JFROG_TOKEN}</password>
+    </server>
+    <server>
+      <id>snapshots</id>
+      <username>${env.JFROG_USER}</username>
+      <password>${env.JFROG_TOKEN}</password>
+    </server>
+    <server>
+      <id>staging</id>
+      <username>${env.JFROG_USER}</username>
+      <password>${env.JFROG_TOKEN}</password>
+    </server>
+    <server>
+      <id>ext-release-local</id>
+      <username>${env.JFROG_USER}</username>
+      <password>${env.JFROG_TOKEN}</password>
+    </server>
+    <server>
+      <id>central</id>
+      <username>${env.CENTRAL_USERNAME}</username>
+      <password>${env.CENTRAL_PSW}</password>
+    </server>
+    <server>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>gpg</id>
+      <properties>
+        <gpg.keyname>${env.GPG_KEYNAME}</gpg.keyname>
+      </properties>
+    </profile>
+
+    <profile>
+      <id>github</id>
+      <repositories>
+        <repository>
+          <id>releases</id>
+          <name>releases</name>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <url>https://bonitasoft.jfrog.io/artifactory/releases</url>
+        </repository>
+        <repository>
+          <id>snapshots</id>
+          <name>snapshots</name>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <url>https://bonitasoft.jfrog.io/artifactory/snapshots</url>
+        </repository>
+        <repository>
+          <id>ext-release-local</id>
+          <name>ext-release-local</name>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <url>https://bonitasoft.jfrog.io/artifactory/ext-release-local</url>
+        </repository>
+        <repository>
+          <id>central-portal-snapshots</id>
+          <name>central-portal-snapshots</name>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>releases</id>
+          <name>releases</name>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+          <url>https://bonitasoft.jfrog.io/artifactory/releases</url>
+        </pluginRepository>
+        <pluginRepository>
+          <id>snapshots</id>
+          <name>snapshots</name>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <url>https://bonitasoft.jfrog.io/artifactory/snapshots</url>
+        </pluginRepository>
+        <pluginRepository>
+          <id>central-portal-snapshots</id>
+          <name>central-portal-snapshots</name>
+          <releases>
+            <enabled>false</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+          <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+
+  <activeProfiles>
+    <activeProfile>gpg</activeProfile>
+    <activeProfile>github</activeProfile>
+  </activeProfiles>
+
+</settings>


### PR DESCRIPTION
## What

Replace `whelk-io/maven-settings-xml-action` with a static [`settings.xml`](settings.xml) copied verbatim to `~/.m2/settings.xml`, removing the third-party dependency from the setup path.

## How it works

The file holds **no credential**: servers reference `${env.*}` expressions that Maven resolves at build time from the job environment populated by Keeper. Consequently, Maven must run **in the same job** as the action (documented in the README, along with the 401 symptoms when the variables do not reach the Maven process).

## Backward compatibility

- Profile ids (`gpg`, `github`), servers, repositories and plugin repositories are identical to the file the whelk-io action generated — verified field by field.
- `GITHUB_ACTOR`/`GITHUB_TOKEN` still back the `github` server; `GITHUB_TOKEN` remains the calling workflow's responsibility, as before.
- Breaking only for consumers that read `~/.m2/settings.xml` outside the job that ran the action (e.g. mounting it into `docker run` without `-e`, or reusing it across jobs): the file now contains `${env.*}` placeholders instead of baked-in credentials.

## Safety nets

- The action preflight-checks that every variable referenced by settings.xml is set, with the list derived from the file itself so it cannot drift.
- CI verifies that `gpg.keyname` resolves through the installed settings and that the exported variables reach the calling workflow.
- CI cache key now rotates with the workflow definition so newly used artifacts actually get cached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
